### PR TITLE
updated tests to reflect conflicts with change

### DIFF
--- a/internal/provider/resource_access_client_app_test.go
+++ b/internal/provider/resource_access_client_app_test.go
@@ -1015,7 +1015,7 @@ func TestAccessClientApp_CustomDiff_RotateSecretValidCombinations(t *testing.T) 
 	}
 }
 
-func TestAccessClientApp_NonExistentRead(t *testing.T) {
+func TestAccessClientApp_InvalidCRUD(t *testing.T) {
 	m := sharedClient()
 
 	d := resourceAccessClientApp().TestResourceData()
@@ -1034,7 +1034,25 @@ func TestAccessClientApp_NonExistentRead(t *testing.T) {
 		t.Fatalf("expected read to succeed, but it did not")
 	}
 
-	revokeSecret(d, m)
+	diag = resourceAccessClientApp().DeleteContext(context.Background(), d, m)
+	if diag == nil {
+		t.Fatalf("expected delete to fail, but it did not")
+
+	}
+
+	d.Set("revoke_now", true)
+	diag = revokeSecret(d, m)
+	if diag == nil {
+		t.Fatalf("expected revoke to fail, but it did not")
+	}
+
+	d.Set("rotate_secret", true)
+	d.Set("revoke_previous_secret_in", "invalidValue")
+	diag = rotateSecret(d, m)
+
+	if diag == nil {
+		t.Fatalf("expected rotate to fail, but it did not")
+	}
 }
 
 func TestAccessClientApp_GetRotationRequest(t *testing.T) {


### PR DESCRIPTION
### Summary:
- updated tests to reflect `conflictsWith` behavior
- added more comprehensive tests to make sure that no edge case scenario is missing this time

The comments in test cases will provide a brief overview of all the test cases included in the corresponding acceptance test. furthermore, unit tests are updated to test for the scenarios that the acceptance tests could not.

### Test results:
```
$ go test -v -coverprofile sp.out -run "TestAccAppdynamicscloudAccessClientApp|TestAccessClientApp" -timeout 60m
=== RUN   TestAccAppdynamicscloudAccessClientAppDataSource_Basic
--- PASS: TestAccAppdynamicscloudAccessClientAppDataSource_Basic (105.11s)
=== RUN   TestAccAppdynamicscloudAccessClientApp_Basic
--- PASS: TestAccAppdynamicscloudAccessClientApp_Basic (683.55s)
=== RUN   TestAccAppdynamicscloudAccessClientApp_Update
--- PASS: TestAccAppdynamicscloudAccessClientApp_Update (452.45s)
=== RUN   TestAccAppdynamicscloudAccessClientApp_NegativeCases
--- PASS: TestAccAppdynamicscloudAccessClientApp_NegativeCases (143.32s)
=== RUN   TestAccAppdynamicscloudAccessClientApp_MultipleCreateDelete
--- PASS: TestAccAppdynamicscloudAccessClientApp_MultipleCreateDelete (90.08s)
=== RUN   TestAccessClientApp_CustomDiff_RotateSecretValidCombinations
--- PASS: TestAccessClientApp_CustomDiff_RotateSecretValidCombinations (0.00s)
=== RUN   TestAccessClientApp_InvalidCRUD
--- PASS: TestAccessClientApp_InvalidCRUD (5.45s)
=== RUN   TestAccessClientApp_GetRotationRequest
--- PASS: TestAccessClientApp_GetRotationRequest (0.00s)
=== RUN   TestAccessClientApp_SingleListToMap
--- PASS: TestAccessClientApp_SingleListToMap (0.00s)
PASS
coverage: 22.6% of statements
ok  	github.com/aniketk-crest/terraform-provider-appdynamics/internal/provider	1480.047s
```
___

Attaching the coverage report here to ensure that nothing is missed to test this time:
[coverage report](https://github.com/AniketK-Crest/terraform-provider-appdynamicscloud/files/10371074/973fdb31-8c06-43a9-9b73-e6de682254fc.pdf)


### Explanation on lines that missed coverage:
- 504 gateway timeout error is unpredictable missing two lines of coverage in create function.
- `rotateSecret` and `revokeSecret` methods are tested individually if those separate unit tests are successful, thus the same is not tested redundantly during create and update