### PR TITLE
Update GitHub project url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Contributing to terraform-provider-appdynamicscloud
+Contributing to appd-cloud-terraform
 =====================================
 
 If you would like to contribute code you can do so through GitHub by
@@ -13,7 +13,7 @@ License
 -------
 
 By contributing your code, you agree to license your contribution under
-the terms of the [Mozilla Public License 2.0](https://github.com/AniketK-Crest/terraform-provider-appdynamicscloud/blob/main/LICENSE)
+the terms of the [Mozilla Public License 2.0](https://github.com/cisco-open/appd-cloud-terraform/blob/main/LICENSE)
 
 All files are released with the MPL-2.0 license.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# terraform-provider-appdynamicscloud
+# appd-cloud-terraform
 
-The Terraform AppDynamics Cloud provider is a plugin that allows Terraform to manage resources on AppDynamics Cloud Platform.
+The AppDynamics Cloud Terraform provider is a plugin that allows Terraform to manage resources on AppDynamics Cloud Platform.
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ Communities provide a place for members or participants to search for informatio
   * idea exchanges where you can suggest ways to improve products and vote for ideas that other community members have posted
   * knowledge base - a collection of articles that captures and organizes helpful community information. 
 
-* [Issues or Enhancement requests: ](https://TODO)  
+* Issues or Enhancement requests:
 Issues and Enhancement requests can be submitted on GitHub repo's issues tab of the repository. Please search if the existing issues resolves your problem before posting a new issue.
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,22 +1,18 @@
-// TODO: Update url
-module github.com/aniketk-crest/terraform-provider-appdynamics
+module github.com/cisco-open/appd-cloud-terraform
 
 go 1.18
 
 require (
-	// TODO: Update url
-	// github.com/aniketk-crest/appdynamicscloud-go-client v0.0.0-00010101000000-000000000000
+	// github.com/cisco-open/appd-cloud-go-client v0.0.0-00010101000000-000000000000
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	golang.org/x/oauth2 v0.3.0
 )
 
-// TODO: Update url
-// replace github.com/aniketk-crest/appdynamicscloud-go-client => ../appdynamicscloud-go-client
+// replace github.com/cisco-open/appd-cloud-go-client => ../appd-cloud-go-client
 
 require (
 	github.com/Jeffail/gabs/v2 v2.6.1
-	// TODO: Update url
-	github.com/aniketk-crest/appdynamicscloud-go-client v1.0.2-0.20221228043829-8b9388d75433
+	github.com/cisco-open/appd-cloud-go-client v1.0.2-0.20221228043829-8b9388d75433
 	github.com/chromedp/cdproto v0.0.0-20221126224343-3a0787b8dd28
 	github.com/chromedp/chromedp v0.8.6
 	github.com/hashicorp/terraform-plugin-docs v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -18,10 +18,8 @@ github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-// TODO: Update url
-github.com/aniketk-crest/appdynamicscloud-go-client v1.0.2-0.20221228043829-8b9388d75433 h1:FOedxEHwApRtRQUpu3tHJX4sOGioaEDHCqldshXpIPE=
-// TODO: Update url
-github.com/aniketk-crest/appdynamicscloud-go-client v1.0.2-0.20221228043829-8b9388d75433/go.mod h1:SID232RH1Jp5kQp/uKxnmV+AGwE9gtPFbT9mLOUn1jk=
+github.com/cisco-open/appd-cloud-go-client v1.0.2-0.20221228043829-8b9388d75433 h1:FOedxEHwApRtRQUpu3tHJX4sOGioaEDHCqldshXpIPE=
+github.com/cisco-open/appd-cloud-go-client v1.0.2-0.20221228043829-8b9388d75433/go.mod h1:SID232RH1Jp5kQp/uKxnmV+AGwE9gtPFbT9mLOUn1jk=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=

--- a/internal/auth/file_utils.go
+++ b/internal/auth/file_utils.go
@@ -25,10 +25,8 @@ import (
 	"os"
 	"time"
 
-	// TODO: Update url
-	client "github.com/aniketk-crest/appdynamicscloud-go-client"
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	client "github.com/cisco-open/appd-cloud-go-client"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 )
 
 var key = []byte("testtesttesttest")

--- a/internal/provider/common_methods.go
+++ b/internal/provider/common_methods.go
@@ -19,8 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/internal/provider/datasource_cloud_query.go
+++ b/internal/provider/datasource_cloud_query.go
@@ -22,8 +22,7 @@ import (
 	"strings"
 
 	container "github.com/Jeffail/gabs/v2"
-	// TODO: Update url
-	cloudQueryApi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudquery"
+	cloudQueryApi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudquery"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/internal/provider/datasource_cloud_regions_aws.go
+++ b/internal/provider/datasource_cloud_regions_aws.go
@@ -17,8 +17,7 @@ package provider
 import (
 	"context"
 
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/internal/provider/datasource_cloud_regions_azure.go
+++ b/internal/provider/datasource_cloud_regions_azure.go
@@ -17,8 +17,7 @@ package provider
 import (
 	"context"
 
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/internal/provider/datasource_cloud_services_aws.go
+++ b/internal/provider/datasource_cloud_services_aws.go
@@ -17,8 +17,7 @@ package provider
 import (
 	"context"
 
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/internal/provider/datasource_cloud_services_azure.go
+++ b/internal/provider/datasource_cloud_services_azure.go
@@ -17,8 +17,7 @@ package provider
 import (
 	"context"
 
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -22,10 +22,8 @@ import (
 	"net/http"
 	"strings"
 
-	// TODO: Update url
-	client "github.com/aniketk-crest/appdynamicscloud-go-client"
-	// TODO: Update url
-	"github.com/aniketk-crest/terraform-provider-appdynamics/internal/auth"
+	client "github.com/cisco-open/appd-cloud-go-client"
+	"github.com/cisco-open/appd-cloud-terraform/internal/auth"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_access_client_app.go
+++ b/internal/provider/resource_access_client_app.go
@@ -19,8 +19,7 @@ import (
 	"fmt"
 	"log"
 
-	// TODO: Update url
-	applicationprincipalmanagement "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/applicationprincipalmanagement"
+	applicationprincipalmanagement "github.com/cisco-open/appd-cloud-go-client/apis/v1/applicationprincipalmanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_access_client_app_test.go
+++ b/internal/provider/resource_access_client_app_test.go
@@ -20,8 +20,7 @@ import (
 	"regexp"
 	"testing"
 
-	// TODO: Update url
-	"github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/applicationprincipalmanagement"
+	"github.com/cisco-open/appd-cloud-go-client/apis/v1/applicationprincipalmanagement"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/internal/provider/resource_cloud_connection_aws.go
+++ b/internal/provider/resource_cloud_connection_aws.go
@@ -19,8 +19,7 @@ import (
 	"fmt"
 	"reflect"
 
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"

--- a/internal/provider/resource_cloud_connection_aws_access_test.go
+++ b/internal/provider/resource_cloud_connection_aws_access_test.go
@@ -20,8 +20,7 @@ import (
 	"regexp"
 	"testing"
 
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/internal/provider/resource_cloud_connection_aws_role_attachment.go
+++ b/internal/provider/resource_cloud_connection_aws_role_attachment.go
@@ -18,8 +18,7 @@ import (
 	"context"
 	"time"
 
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_cloud_connection_aws_role_attachment_test.go
+++ b/internal/provider/resource_cloud_connection_aws_role_attachment_test.go
@@ -20,8 +20,7 @@ import (
 	"regexp"
 	"testing"
 
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/internal/provider/resource_cloud_connection_aws_role_test.go
+++ b/internal/provider/resource_cloud_connection_aws_role_test.go
@@ -20,8 +20,7 @@ import (
 	"regexp"
 	"testing"
 
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/internal/provider/resource_cloud_connection_azure.go
+++ b/internal/provider/resource_cloud_connection_azure.go
@@ -18,8 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"

--- a/internal/provider/resource_cloud_connection_azure_test.go
+++ b/internal/provider/resource_cloud_connection_azure_test.go
@@ -20,8 +20,7 @@ import (
 	"regexp"
 	"testing"
 
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/internal/provider/sweeper_test.go
+++ b/internal/provider/sweeper_test.go
@@ -21,12 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	// TODO: Update url
-	client "github.com/aniketk-crest/appdynamicscloud-go-client"
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
-	// TODO: Update url
-	"github.com/aniketk-crest/terraform-provider-appdynamics/internal/auth"
+	client "github.com/cisco-open/appd-cloud-go-client"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
+	"github.com/cisco-open/appd-cloud-terraform/internal/auth"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -22,14 +22,10 @@ import (
 	"net/http"
 	"time"
 
-	// TODO: Update url
-	client "github.com/aniketk-crest/appdynamicscloud-go-client"
-	// TODO: Update url
-	cloudappprincipalmgmtapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/applicationprincipalmanagement"
-	// TODO: Update url
-	cloudconnectionapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudconnections"
-	// TODO: Update url
-	cloudqueryapi "github.com/aniketk-crest/appdynamicscloud-go-client/apis/v1/cloudquery"
+	client "github.com/cisco-open/appd-cloud-go-client"
+	cloudappprincipalmgmtapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/applicationprincipalmanagement"
+	cloudconnectionapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudconnections"
+	cloudqueryapi "github.com/cisco-open/appd-cloud-go-client/apis/v1/cloudquery"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/main.go
+++ b/main.go
@@ -17,8 +17,7 @@ package main
 import (
 	"flag"
 
-	// TODO: Update url
-	"github.com/aniketk-crest/terraform-provider-appdynamics/internal/provider"
+	"github.com/cisco-open/appd-cloud-terraform/internal/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
@@ -44,9 +43,8 @@ func main() {
 	// 	},
 	// }
 
-	// TODO: Update url
 	// if debugMode {
-	// 	err := plugin.Debug(context.Background(), "github.com/aniketk-crest/terraform-provider-appdynamics", opts)
+	// 	err := plugin.Debug(context.Background(), "github.com/cisco-open/appd-cloud-terraform", opts)
 	// 	if err != nil {
 	// 		log.Fatal(err.Error())
 	// 	}


### PR DESCRIPTION
## Description

Updates all GitHub project url references to reflect org migration and simplified project name. Also updates references to the Go client url, which the Terraform provider depends on.

These are potentially breaking changes, and should be thoroughly tested alongside the Go client.

See also: https://github.com/cisco-open/appdynamicscloud-go-client/pull/2

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)